### PR TITLE
Removing @constructor and handling object methods.

### DIFF
--- a/lib/goog_define_class.js
+++ b/lib/goog_define_class.js
@@ -33,23 +33,39 @@ module.exports = function(babel) {
     return expressionStatement;
   }
 
+  function genFromFunctionExpression(kind, prop) {
+    return t.classMethod(kind, prop.key, prop.value.params, getBody(prop));
+  }
+
   /**
    * t.classMethod(kind, key, params, body, computed, static)
    * @param prop
    * @return {*}
    */
-  function toClassMethod(prop) {
+  function functionExpressionToClassMethod(prop) {
+    return anyToClassMethod(prop, genFromFunctionExpression);
+  }
+
+  function genFromObjectMethod(kind, prop) {
+    return t.classMethod(kind, prop.key, prop.params, prop.body);
+  }
+
+  function objectMethodToClassMethod(prop) {
+    return anyToClassMethod(prop, genFromObjectMethod);
+  }
+
+  function anyToClassMethod(prop, methodGen) {
     const name = prop.key.name;
     const kind = name === 'constructor' ? 'constructor' : 'method';
 
-    const method = t.classMethod(kind, prop.key, prop.value.params, getBody(prop));
+    const method = methodGen(kind, prop);
     // Copy comments, if any.
     const comments = prop.leadingComments;
     if (comments) {
       method.leadingComments = comments;
     }
 
-    return method
+    return method;
   }
 
   /**
@@ -62,6 +78,22 @@ module.exports = function(babel) {
     } catch (e) {
       return null;
     }
+  }
+
+  const constructorRe = /[ \t]*\*[ \t]*@constructor[ \t]*\n/;
+
+  /**
+   * Remove the " * @constructor" line from the last comment
+   * before the constructor.
+   */
+  function removeConstructorComment(constructor) {
+    if (!constructor) return;
+    const lastComment =
+      constructor.leadingComments &&
+      constructor.leadingComments[constructor.leadingComments.length - 1];
+    if (!lastComment) return;
+    const oldValue = lastComment.value;
+    lastComment.value = oldValue.replace(constructorRe, '');
   }
 
   return {
@@ -81,9 +113,14 @@ module.exports = function(babel) {
         let classMethods = [];
         objectExpression.properties.forEach(prop => {
           if (t.isFunctionExpression(prop.value)) {
-            classMethods.push(toClassMethod(prop));
+            classMethods.push(functionExpressionToClassMethod(prop));
+          } else if (t.isObjectMethod(prop)) {
+            classMethods.push(objectMethodToClassMethod(prop));
           } else if (prop.key.name === 'statics') {
             statics = prop.value.properties;
+          } else {
+            // Prevent silently dropping properties.
+            throw new Error('Unrecognised expression type: ', prop.type);
           }
         });
 
@@ -91,11 +128,13 @@ module.exports = function(babel) {
         const superClass = findParentClass(declaration);
         const decorators = [];
 
+        const constructorMethod = classMethods
+            .find(method => method.kind === 'constructor');
+        removeConstructorComment(constructorMethod);
+
         // Need to add a super() class in the body.
         if (superClass !== null) {
           // Find the constructor.
-          const constructorMethod = classMethods
-              .find(method => method.kind === 'constructor');
           if (constructorMethod) {
             // Add the super(<constructor params>) at the beginning of the fn.
             constructorMethod.body.body.unshift(

--- a/test/inheritance_es5.js
+++ b/test/inheritance_es5.js
@@ -7,13 +7,20 @@ const FooBar = goog.defineClass(Parent, {
   /**
    * Creates a new instance of...
    * @param {Object} name
+   * @constructor
    */
   constructor: function(name) {
     this.name = name;
 
     /** @export {string} */
     this.somethingElse = '';
+  },
+
+  /* A comment */
+  newStyle(paramOne, paramTwo) {
+    console.log('foo');
   }
+
 });
 
 exports = FooBar;

--- a/test/inheritance_es6.js
+++ b/test/inheritance_es6.js
@@ -18,6 +18,11 @@ class FooBar extends Parent {
     this.somethingElse = '';
   }
 
+  /* A comment */
+  newStyle(paramOne, paramTwo) {
+    console.log('foo');
+  }
+
 }
 
 exports = FooBar;


### PR DESCRIPTION
The converter now removes the (unnecessary in es6) @constructor
annotations in the comments.

It also properly handles es6-style object methods, i.e. methods
defined on the defineClass object, like:
  goog.defineClass(null, {
    aMethod(foo, bar) { ... }
  }