### PR TITLE
A quite ugly way to escape Closure type casts because Babel strips them.

### DIFF
--- a/lib/plugin_runner.js
+++ b/lib/plugin_runner.js
@@ -4,11 +4,13 @@ const googDefineClass = require('./goog_define_class');
 
 class PluginRunner {
   static run(fileName) {
-    const src = fs.readFileSync(fileName, 'utf8');
+    let src = fs.readFileSync(fileName, 'utf8');
     // Skip files without goog.defineClass.
     if (src.indexOf('goog.defineClass') === -1) {
       return src;
     }
+
+    src = escapeClosureTypeCasts(src);
 
     const out = babel.transform(src, {
       plugins: [googDefineClass]
@@ -16,13 +18,46 @@ class PluginRunner {
 
     // Add an empty line if the original ends with empty line and the
     // transformed doesn't.
-    const code = out.code;
+    let code = out.code;
+
+    code = restoreClosureTypeCasts(code);
+
     if (src.endsWith('\n') && !code.endsWith('\n')) {
       return code + '\n';
     }
 
     return code;
   }
+}
+
+const CAST_PREFIX = 'GOOGCLASS_TO_ES6CLASS_CLOSURE_TYPE_CAST';
+
+// Searches for: /** @type...*/
+const COMMENT_RE = '\\/\\*\\*\\s*@type([^*]|\\*[^/])+\\*\\/';
+
+/**
+ * Babel strips (unnecessary in their opinion) parentheses from Closure
+ * type cast expressions. We must escape them to avoid stripping.
+ */
+function escapeClosureTypeCasts(src) {
+  // Find phrases like: /** @type {x} */ (foo)
+  const castRe = new RegExp(`${COMMENT_RE}\\s*\\(`, 'g');
+  return src.replace(castRe, (match) => {
+    const withoutParen = match.slice(0, -1);
+    return `${CAST_PREFIX}(${withoutParen}`;
+  });
+}
+
+/**
+ * Restore Closure type casts escaped by escapeClosureTypeCasts.
+ */
+function restoreClosureTypeCasts(src) {
+  // Find all the escaped type casts.
+  const castRe = new RegExp(`${CAST_PREFIX}\\((\\s*)(${COMMENT_RE})`, 'g');
+  src = src.replace(castRe, (match, whitespace, comment) => {
+    return `${comment}${whitespace}(`;
+  });
+  return src;
 }
 
 module.exports = PluginRunner;

--- a/lib/plugin_runner.js
+++ b/lib/plugin_runner.js
@@ -41,11 +41,8 @@ const COMMENT_RE = '\\/\\*\\*\\s*@type([^*]|\\*[^/])+\\*\\/';
  */
 function escapeClosureTypeCasts(src) {
   // Find phrases like: /** @type {x} */ (foo)
-  const castRe = new RegExp(`${COMMENT_RE}\\s*\\(`, 'g');
-  return src.replace(castRe, (match) => {
-    const withoutParen = match.slice(0, -1);
-    return `${CAST_PREFIX}(${withoutParen}`;
-  });
+  const castRe = new RegExp(`(${COMMENT_RE}\\s*)\\(`, 'g');
+  return src.replace(castRe, CAST_PREFIX + '($1');
 }
 
 /**
@@ -54,10 +51,7 @@ function escapeClosureTypeCasts(src) {
 function restoreClosureTypeCasts(src) {
   // Find all the escaped type casts.
   const castRe = new RegExp(`${CAST_PREFIX}\\((\\s*)(${COMMENT_RE})`, 'g');
-  src = src.replace(castRe, (match, whitespace, comment) => {
-    return `${comment}${whitespace}(`;
-  });
-  return src;
+  return src.replace(castRe, '$2$1(');
 }
 
 module.exports = PluginRunner;

--- a/test/inheritance_es5.js
+++ b/test/inheritance_es5.js
@@ -19,6 +19,7 @@ const FooBar = goog.defineClass(Parent, {
   /* A comment */
   newStyle(paramOne, paramTwo) {
     console.log('foo');
+    const severityName = /** @type {string} */ (fn(scope));
   }
 
 });

--- a/test/inheritance_es6.js
+++ b/test/inheritance_es6.js
@@ -21,6 +21,7 @@ class FooBar extends Parent {
   /* A comment */
   newStyle(paramOne, paramTwo) {
     console.log('foo');
+    const severityName = /** @type {string} */ (fn(scope));
   }
 
 }


### PR DESCRIPTION
Babel strips the parentheses around /** @type {...} */ (foo) expressions.
This is indented Babel behaviour as explained in:
babel/babel#3946

To remedy this, we use regular expressions (ugh) to find type casts
and replace them with bogus function calls, which whe later revert.